### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a server based on the [Model Context Protocol](https://modelcontextprotocol.io) for scraping Weibo user information, feeds, and search functionality. This server can help retrieve detailed information about Weibo users, feed content, and perform user searches.
 
+<a href="https://glama.ai/mcp/servers/@Selenium39/mcp-server-weibo">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Selenium39/mcp-server-weibo/badge" alt="Weibo Server MCP server" />
+</a>
+
 ## Installation
 
 Install from source code:
@@ -60,4 +64,4 @@ MIT License
 
 ## Disclaimer
 
-This project is not affiliated with Weibo and is for learning and research purposes only. 
+This project is not affiliated with Weibo and is for learning and research purposes only.


### PR DESCRIPTION
This PR adds a badge for the [Weibo MCP Server](https://glama.ai/mcp/servers/@Selenium39/mcp-server-weibo) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Selenium39/mcp-server-weibo">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Selenium39/mcp-server-weibo/badge" alt="Weibo Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.